### PR TITLE
Fix for select2 changes

### DIFF
--- a/style.css
+++ b/style.css
@@ -204,7 +204,7 @@ h4 {
 }
 
 /* --- Lists 列表樣式 --- */
-ol, ul {
+ol, ul:has(li) {
     margin-block-start: 10px;
     margin-block-end: 10px;
     margin-inline-start: 3px;


### PR DESCRIPTION
## Description

I recent PR to ST staging ([here](https://github.com/SillyTavern/SillyTavern/pull/4207#issue-3177576998)) changes how select2 elements are styled, and it causes a visual bug with Moonlit Echoes. This should fix that.

## Method
The `ul` CSS block from this extension bleeds into the select2 `ul` element, causing an extra line when no items are selected. This fix just makes the CSS only apply when the `ul` has items in it, removing the unwanted space in the select2 elements.