### PR TITLE
Adding option to minimize user messages in echo style

### DIFF
--- a/index.js
+++ b/index.js
@@ -598,6 +598,24 @@ const themeCustomSettings = [
     },
     {
         "type": "checkbox",
+        "varId": "hideUserAvatar",
+        "displayText": t`[Echo] Minimize User Messages`,
+        "default": false,
+        "category": "chat-echo",
+        "description": t`Hide user avatars and minimizes the height of user messages in the Echo style.`,
+        "cssBlock": `
+            body.echostyle #chat div.mes[is_user="true"] div.mes_text::before {
+                content: unset;
+            }
+
+            body.echostyle #chat div.mes[is_user="true"] div.mes_text {
+                padding-left: 20px !important;
+                min-height: unset;
+            }
+        `
+    },
+    {
+        "type": "checkbox",
         "varId": "hideMobileEchoBackground",
         "displayText": t`[Echo] Hide Message Background on Mobile`,
         "default": false,


### PR DESCRIPTION
## Description

This adds a toggle option to Echo-Style that hides the user avatar and minimizes the height of user messages. This may be a personal preference (I don't use user avatars), but I've been using this as custom CSS for awhile with the extension and figured I'd just make it an option. Let me know if you think this is an appropriate option :)

## Method

This just overrides user message CSS to unset the `content` of the avatar, move the `padding-left` to compensate, then also remove the `min-height` to make user messages shrink to content.