### PR TITLE
Fixing alignment with rectangular avatars

### DIFF
--- a/style.css
+++ b/style.css
@@ -1164,9 +1164,6 @@ body.big-avatars #chat .mes[is_user="true"] {
 
 /* Avatar: Hidden 頭像：「隱藏角色頭像」 */
 body.hideChatAvatars #chat {
-    .ch_name {
-        margin-left: 10px;
-    }
     .mes {
         .mes_timer,
         .mesIDDisplay,
@@ -1183,6 +1180,36 @@ body.hideChatAvatars {
     .swipe_left,
     .swipeRightBlock {
         bottom: 30px !important;
+    }
+}
+
+/* These styles require 10px margin-left for the name */
+body.hideChatAvatars.echostyle #chat,
+body.hideChatAvatars.whisperstyle #chat,
+body.hideChatAvatars.hushstyle #chat,
+body.hideChatAvatars.tidestyle #chat {
+  .ch_name {
+    margin-left: 10px;
+  }
+}
+
+/* These need 0 margin-left for the name */
+body.hideChatAvatars.flatchat #chat,
+body.hideChatAvatars.bubblechat #chat,
+body.hideChatAvatars.ripplestyle #chat {
+  .ch_name {
+    margin-left: unset;
+  }
+}
+
+/* 漣漪訊息修正 */
+body.hideChatAvatars.ripplestyle #chat {
+    .mes .mesAvatarWrapper {
+        margin-top: 35px;
+        top: 35px;
+    }
+    .mes_text {
+        margin-top: unset;
     }
 }
 
@@ -1570,6 +1597,10 @@ body.echostyle #chat {
         opacity: 1 !important;
         border-radius: 0;
     }
+}
+
+body.echostyle.big-avatars #chat .mes .avatar {
+  min-width: unset !important;  /* Fix alignment issue in echo style with big avatars */
 }
 
 /* --- Chat Style: Whisper 聊天風格：「低語」 --- */
@@ -3683,10 +3714,6 @@ body.big-avatars.echostyle #chat {
     .mes_text {
         margin-bottom: 15px !important;
     }
-    .mes_timer, .mesIDDisplay, .tokenCounterDisplay {
-        transform: unset !important;
-        margin-bottom: 8px;
-    }
 
     @media screen and (max-width: 1000px) {
         .mes[is_user="false"] .ch_name {
@@ -3697,9 +3724,17 @@ body.big-avatars.echostyle #chat {
         }
     }
 }
-body.big-avatars.whisperstyle #chat,
-body.big-avatars.hushstyle #chat,
-body.big-avatars.tidestyle #chat {
+/* in echo style + big-avatar + hide avatars, -22 is too squished (see above) */
+body.big-avatars.echostyle.hideChatAvatars #chat {
+    .ch_name {
+        margin-top: -15px !important;
+    }
+}
+
+/* Shift these downward if using big avatars, but only if we aren't hiding them */
+body.big-avatars.whisperstyle:not(.hideChatAvatars) #chat,
+body.big-avatars.hushstyle:not(.hideChatAvatars) #chat,
+body.big-avatars.tidestyle:not(.hideChatAvatars) #chat {
     .mes_timer, .mesIDDisplay, .tokenCounterDisplay {
         transform: unset !important;
     }
@@ -3738,21 +3773,6 @@ body.hushstyle {
 .mes.smallSysMes::before,
 .mes.smallSysMes::after {
     display: none !important;
-}
-
-/* 漣漪訊息修正 */
-body.hideChatAvatars.ripplestyle #chat {
-    .ch_name {
-        margin-left: unset;
-    }
-
-    .mes .mesAvatarWrapper {
-        margin-top: 35px;
-        top: 35px;
-    }
-    .mes_text {
-        margin-top: unset;
-    }
 }
 
 /* 標題間距修正 */


### PR DESCRIPTION
## Description

I noticed several alignment issues with message name, generation time, and generation tokens when using `Rectangular` avatars or `Hide Chat Avatars` in certain styles . Some other issues occurred when these two options were combined.

1. Alignment issue in `Flat` and `Bubble` styles when using `Hide Chat Avatars`

![flat](https://github.com/user-attachments/assets/18e8f906-13e7-45f9-a6de-4613a88aaeb5)
Fixed:
![flat_fixed](https://github.com/user-attachments/assets/dfd83908-dd70-4010-a1e1-3e1c13767860)

2. Alignment issue in `Echo`, `Whisper`, `Hush`, and `Tide` when using `Hide Chat Avatars`

![hidden](https://github.com/user-attachments/assets/37a64b58-46f4-490b-abba-b289295e9d02)
Fixed:
![hidden_fixed](https://github.com/user-attachments/assets/ef6c45e4-27dd-481f-b104-7f8dc5f7bc16)

3. Alignment issue in `Echo` style with `Rectangular Avatar`

![echo_align](https://github.com/user-attachments/assets/242f491f-f30d-444f-bf18-2dd494276c5f)
Fixed:
![echo_fixed](https://github.com/user-attachments/assets/8b7578f2-3b5b-44ca-b227-34edf9ce0abf)

4. Issue in `Echo`, `Whisper`, `Hish`, and `Tide` when using `Rectangular Avatars` and `Hide Chat Avatars`

![both](https://github.com/user-attachments/assets/b1874aba-9026-4706-b1ff-09a10861243a)
Fixed:
![hidden_fixed](https://github.com/user-attachments/assets/ef6c45e4-27dd-481f-b104-7f8dc5f7bc16)


## Method

- Issue 1 was addressed by only specifying `margin-left: 10px` when using `hiddenChatAvatars` in the `Echo`, `Whisper`, `Hush`, and `Tide` styles rather than all of them. 
- Issue 2 was addressed along with issue 1 because the increased specificity meant that the `margin-left: 10px` was no longer being overridden by other styles.
- Issue 3 was addressed by using `min-width: unset;` in `Echo` with `big-avatars`
- Issue 4 was addressed by only using `transform: unset` when NOT with `hiddenChatAvatars`, along with the fix from 2.


## Notes
- This was tested on Firefox, Edge, and Chrome in Windows 11. Needs testing on Safari and Mobile.