### PR TITLE
Fix Ripple avatar image quality

### DIFF
--- a/index.js
+++ b/index.js
@@ -827,6 +827,8 @@ function initChatDisplaySwitcher() {
             case "6": document.body.classList.add("ripplestyle"); break;
             case "7": document.body.classList.add("tidestyle"); break;
         }
+
+        window.updateAvatars?.();
     }
 
     // Always add our options

--- a/src/core/observers.js
+++ b/src/core/observers.js
@@ -103,7 +103,9 @@ export function initAvatarInjector() {
     function updateAvatars() {
         const context = SillyTavern.getContext();
         const settings = getExtensionSettings(context) || {};
-        const preferOriginal = settings.useOriginalAvatarImages === true;
+        const preferOriginal =
+            settings.useOriginalAvatarImages === true ||
+            document.body.classList.contains('ripplestyle');
 
         document.querySelectorAll('.mes').forEach((mes) => {
             const avatarImg = mes.querySelector('.avatar img');

--- a/src/services/slash-commands.js
+++ b/src/services/slash-commands.js
@@ -37,6 +37,8 @@ export function initializeSlashCommands() {
 
             document.body.classList.add(styleName);
 
+            window.updateAvatars?.();
+
             localStorage.setItem('savedChatStyle', styleValue);
 
             return t`Chat style switched to ${styleName}`;


### PR DESCRIPTION
This pull request enhances the chat style switching functionality by ensuring that avatar images update correctly when the chat style is changed, particularly when the "ripplestyle" is applied. The changes ensure that avatar preferences are respected and the UI remains consistent after style changes.

**Avatar update improvements:**

* The `updateAvatars` function now treats the "ripplestyle" chat style as a reason to prefer original avatar images, ensuring visual consistency when this style is active.

* Calls to `window.updateAvatars()` have been added after chat style switches in both the chat display switcher and slash command handler, so avatar images are immediately updated to reflect the new style. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R830-R831) [[2]](diffhunk://#diff-0c7d4d66d02050edbafee2f263e32c62a4c609b8af390f591dcb4d35ffea454cR40-R41)